### PR TITLE
Update for breaking changes in the redbot package

### DIFF
--- a/bansync/bansync.py
+++ b/bansync/bansync.py
@@ -2,13 +2,13 @@ import asyncio
 from typing import List
 
 import discord
-from discord.ext import commands
 
-from redbot.core.i18n import CogI18n
+from redbot.core import commands
+from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.chat_formatting import box, pagify
 
 GuildList = List[discord.Guild]
-_ = CogI18n("BanSync", __file__)
+_ = Translator("BanSync", __file__)
 
 # Strings go here for ease of modification with pygettext
 INTERACTIVE_PROMPT_I = _("Select a server to add to the sync list by number, "
@@ -29,6 +29,7 @@ UNWORTHY = _("You are not worthy")
 BANMOJI = '\U0001f528'
 
 
+@cog_i18n(_)
 class BanSync:
     """
     synchronize your bans

--- a/calculator/calc.py
+++ b/calculator/calc.py
@@ -1,16 +1,16 @@
 import sys
 
-from discord.ext import commands
-
-from redbot.core.bot import Red, RedContext
+from redbot.core.bot import Red
+from redbot.core import commands
 # from redbot.core import checks
-from redbot.core.i18n import CogI18n
+from redbot.core.i18n import Translator, cog_i18n
 
 from .jailer import run_jailed
 
-_ = CogI18n('Calculator', __file__)
+_ = Translator('Calculator', __file__)
 
 
+@cog_i18n(_)
 class Calculator:
     """
     This provides a safe(er) method for allowing math
@@ -37,7 +37,7 @@ class Calculator:
         return sys.platform == 'linux'
 
     @commands.command(name='calc', aliases=['calculate'])
-    async def calculate(self, ctx: RedContext, *, expression: str=""):
+    async def calculate(self, ctx: commands.Context, *, expression: str=""):
         """
         get the result of an expression
 

--- a/calculator/jailer.py
+++ b/calculator/jailer.py
@@ -6,7 +6,7 @@ import shlex
 import functools
 import asyncio
 
-from redbot.core.bot import RedContext
+from redbot.core import commands
 from redbot.core.utils.chat_formatting import pagify
 
 
@@ -20,7 +20,7 @@ async def run_jailed(
         *, expr: str,
         timeout: int=60,
         memlimit: int=60,
-        ctx: RedContext):
+        ctx: commands.Context):
 
     file_str = str(pathlib.Path(__file__).parent / 'jailed_calc.py')
     run_args = [sys.executable, file_str]

--- a/embedmaker/embedmaker.py
+++ b/embedmaker/embedmaker.py
@@ -1,8 +1,7 @@
 import discord
 import logging
-from discord.ext import commands
 
-from redbot.core import Config, RedContext
+from redbot.core import Config, commands
 from redbot.core import checks
 from redbot.core.utils.chat_formatting import pagify
 from .serialize import deserialize_embed, serialize_embed
@@ -29,7 +28,7 @@ class EmbedMaker:
         self.config.register_guild(active=True)
 
     @commands.group(name="embed")
-    async def _embed(self, ctx: RedContext):
+    async def _embed(self, ctx: commands.Context):
         """
         """
         if ctx.invoked_subcommand is None:
@@ -38,7 +37,7 @@ class EmbedMaker:
     @commands.guild_only()
     @commands.bot_has_permissions(embed_links=True)
     @_embed.command(name='advmake', hidden=True)
-    async def make_adv(self, ctx: RedContext, name: str, *, data: str):
+    async def make_adv(self, ctx: commands.Context, name: str, *, data: str):
         """
         makes an embed from valid yaml
 
@@ -66,7 +65,7 @@ class EmbedMaker:
     @commands.bot_has_permissions(embed_links=True)
     @checks.is_owner()
     @_embed.command(name='advmakeglobal', hidden=True)
-    async def make_global_adv(self, ctx: RedContext, name: str, *, data: str):
+    async def make_global_adv(self, ctx: commands.Context, name: str, *, data: str):
         """
         makes an embed from valid yaml
 
@@ -91,7 +90,7 @@ class EmbedMaker:
 
     @commands.guild_only()
     @_embed.command(name="make")
-    async def _make(self, ctx: RedContext, name: str, *, content: str):
+    async def _make(self, ctx: commands.Context, name: str, *, content: str):
         """
         makes an embed
         """
@@ -113,7 +112,7 @@ class EmbedMaker:
 
     @checks.is_owner()
     @_embed.command(name='makeglobal')
-    async def make_global(self, ctx: RedContext, name: str, *, content: str):
+    async def make_global(self, ctx: commands.Context, name: str, *, content: str):
         """
         make a global embed
         """
@@ -133,7 +132,7 @@ class EmbedMaker:
             await group.embed.set(serialize_embed(e))
 
     @_embed.command(name="list")
-    async def _list(self, ctx: RedContext):
+    async def _list(self, ctx: commands.Context):
         """
         lists the embeds here
         """
@@ -162,7 +161,7 @@ class EmbedMaker:
 
     @commands.guild_only()
     @_embed.command(name="remove")
-    async def _remove(self, ctx: RedContext, name: str):
+    async def _remove(self, ctx: commands.Context, name: str):
         """
         removes an embed
         """
@@ -183,7 +182,7 @@ class EmbedMaker:
 
     @checks.is_owner()
     @_embed.command(name="rmglobal")
-    async def remove_global(self, ctx: RedContext, name: str):
+    async def remove_global(self, ctx: commands.Context, name: str):
         """
         removes a global embed
         """
@@ -192,7 +191,7 @@ class EmbedMaker:
 
     @commands.bot_has_permissions(embed_links=True)
     @_embed.command()
-    async def drop(self, ctx: RedContext, name: str):
+    async def drop(self, ctx: commands.Context, name: str):
         """
         drops an embed here
         """
@@ -207,7 +206,7 @@ class EmbedMaker:
 
     @checks.is_owner()
     @_embed.command(name="dropglobal")
-    async def drop_global(self, ctx: RedContext, name: str):
+    async def drop_global(self, ctx: commands.Context, name: str):
         """
         drop a global embed here
         """
@@ -218,7 +217,7 @@ class EmbedMaker:
 
     @checks.admin()
     @_embed.command()
-    async def dm(self, ctx: RedContext, name: str, user: discord.Member):
+    async def dm(self, ctx: commands.Context, name: str, user: discord.Member):
         """
         DMs an embed
         """
@@ -234,7 +233,7 @@ class EmbedMaker:
 
     @checks.admin()
     @_embed.command()
-    async def dmglobal(self, ctx: RedContext, name: str, user: discord.Member):
+    async def dmglobal(self, ctx: commands.Context, name: str, user: discord.Member):
         """
         DMs a global embed
         """
@@ -250,7 +249,7 @@ class EmbedMaker:
 
     @commands.guild_only()
     @_embed.command(name='frommsg')
-    async def from_message(self, ctx: RedContext, name: str, _id: int):
+    async def from_message(self, ctx: commands.Context, name: str, _id: int):
         """
         Store's a message's embed
         """
@@ -270,7 +269,7 @@ class EmbedMaker:
 
     @checks.is_owner()
     @_embed.command(name='globalfrommsg')
-    async def global_from_message(self, ctx: RedContext, name: str, _id: int):
+    async def global_from_message(self, ctx: commands.Context, name: str, _id: int):
         """
         stores a message's embed
         """

--- a/embedmaker/yaml_parse.py
+++ b/embedmaker/yaml_parse.py
@@ -1,6 +1,6 @@
 import yaml
 import discord
-from discord.ext import commands
+from redbot.core import commands
 from .serialize import template, deserialize_embed
 from .utils import parse_time
 

--- a/genreplace/genreplace.py
+++ b/genreplace/genreplace.py
@@ -1,6 +1,5 @@
 import dice as dicelib
-from discord.ext import commands
-from redbot.core import RedContext, checks
+from redbot.core import commands, checks
 from redbot.core.bot import Red
 import random
 from .dice import StatefulDie
@@ -27,7 +26,7 @@ class GenReplace:
     @checks.admin()
     @commands.guild_only()
     @commands.command(hidden=True)
-    async def enablestateful(self, ctx: RedContext, enable: bool=True):
+    async def enablestateful(self, ctx: commands.Context, enable: bool=True):
         """
         enables dice less prone to streaks
         """
@@ -57,7 +56,7 @@ class GenReplace:
         await ctx.maybe_send_embed(response)
 
     @commands.command()
-    async def roll(self, ctx: RedContext, sides: int=6):
+    async def roll(self, ctx: commands.Context, sides: int=6):
         """
         Rolls a die
         """

--- a/guildblacklist/guildblacklist.py
+++ b/guildblacklist/guildblacklist.py
@@ -3,10 +3,9 @@ from pathlib import Path
 import itertools
 
 import discord
-from discord.ext import commands
 
-from redbot.core.i18n import CogI18n
-from redbot.core import Config, RedContext
+from redbot.core.i18n import Translator, cog_i18n
+from redbot.core import Config, commands
 from redbot.core import __version__ as redversion
 from redbot.core.utils.chat_formatting import box, pagify
 try:
@@ -16,7 +15,7 @@ except ImportError:
 else:
     DC_AVAILABLE = True
 
-_ = CogI18n("GuildBlacklist", __file__)
+_ = Translator("GuildBlacklist", __file__)
 
 log = logging.getLogger('red.guildblacklist')
 
@@ -27,6 +26,7 @@ FMT_ERROR = _("That file didn't appear to be a valid settings file")
 DC_UNAVAILABLE = _("Data conversion is not available in your install.")
 
 
+@cog_i18n(_)
 class GuildBlacklist:
     """
     prevent the bot from joining servers by either
@@ -48,7 +48,7 @@ class GuildBlacklist:
         )
         self.config.register_global(**self.default_globals)
 
-    async def __local_check(self, ctx: RedContext):
+    async def __local_check(self, ctx: commands.Context):
         return await ctx.bot.is_owner(ctx.author)
 
     async def on_guild_join(self, guild: discord.Guild):
@@ -61,7 +61,7 @@ class GuildBlacklist:
                 await guild.leave()
 
     @commands.group(name="guildblacklist")
-    async def gbl(self, ctx: RedContext):
+    async def gbl(self, ctx: commands.Context):
         """
         settings for guildblacklisting
         """
@@ -69,7 +69,7 @@ class GuildBlacklist:
             await ctx.send_help()
 
     @gbl.command(name='debuginfo', hidden=True)
-    async def dbg_info(self, ctx: RedContext):
+    async def dbg_info(self, ctx: commands.Context):
         """
         debug info
         """
@@ -82,7 +82,7 @@ class GuildBlacklist:
         await ctx.send(box(ret))
 
     @gbl.command(name="add")
-    async def gbl_add(self, ctx: RedContext, *ids: int):
+    async def gbl_add(self, ctx: commands.Context, *ids: int):
         """
         add one or more ids to the blacklist.
         This can be the ID or a guild, or a user.
@@ -99,7 +99,7 @@ class GuildBlacklist:
         await ctx.tick()
 
     @gbl.command(name="list")
-    async def gbl_list(self, ctx: RedContext):
+    async def gbl_list(self, ctx: commands.Context):
         """
         list blacklisted IDs
         """
@@ -112,7 +112,7 @@ class GuildBlacklist:
         await ctx.tick()
 
     @gbl.command(name="remove")
-    async def gbl_remove(self, ctx: RedContext, *ids: int):
+    async def gbl_remove(self, ctx: commands.Context, *ids: int):
         """
         remove one or more ids from the blacklist
         """
@@ -125,7 +125,7 @@ class GuildBlacklist:
         await ctx.tick()
 
     @gbl.command(name='import', disabled=True)
-    async def gbl_import(self, ctx: RedContext, path: str):
+    async def gbl_import(self, ctx: commands.Context, path: str):
         """
         pass the full path of the v2 settings.json
         for this cog

--- a/guildwhitelist/guildwhitelist.py
+++ b/guildwhitelist/guildwhitelist.py
@@ -3,10 +3,9 @@ from pathlib import Path
 import itertools
 
 import discord
-from discord.ext import commands
 
-from redbot.core.i18n import CogI18n
-from redbot.core import Config, RedContext
+from redbot.core.i18n import Translator, cog_i18n
+from redbot.core import Config, commands
 from redbot.core import __version__ as redversion
 from redbot.core.utils.chat_formatting import box, pagify
 try:
@@ -16,7 +15,7 @@ except ImportError:
 else:
     DC_AVAILABLE = True
 
-_ = CogI18n("GuildWhitelist", __file__)
+_ = Translator("GuildWhitelist", __file__)
 
 log = logging.getLogger('red.guildwhitelist')
 
@@ -27,6 +26,7 @@ FMT_ERROR = _("That file didn't appear to be a valid settings file")
 DC_UNAVAILABLE = _("Data conversion is not available in your install.")
 
 
+@cog_i18n(_)
 class GuildWhitelist:
     """
     prevent the bot from joining servers who are not whitelisted
@@ -48,7 +48,7 @@ class GuildWhitelist:
         )
         self.config.register_global(**self.default_globals)
 
-    async def __local_check(self, ctx: RedContext):
+    async def __local_check(self, ctx: commands.Context):
         return await ctx.bot.is_owner(ctx.author)
 
     async def on_guild_join(self, guild: discord.Guild):
@@ -64,7 +64,7 @@ class GuildWhitelist:
                 await guild.leave()
 
     @commands.group(name="guildwhitelist")
-    async def gwl(self, ctx: RedContext):
+    async def gwl(self, ctx: commands.Context):
         """
         settings for guildwhitelisting
         """
@@ -72,7 +72,7 @@ class GuildWhitelist:
             await ctx.send_help()
 
     @gwl.command(name='debuginfo', hidden=True)
-    async def dbg_info(self, ctx: RedContext):
+    async def dbg_info(self, ctx: commands.Context):
         """
         debug info
         """
@@ -85,7 +85,7 @@ class GuildWhitelist:
         await ctx.send(box(ret))
 
     @gwl.command(name="add")
-    async def gwl_add(self, ctx: RedContext, *ids: int):
+    async def gwl_add(self, ctx: commands.Context, *ids: int):
         """
         add one or more ids to the whitelist.
         This can be the ID or a guild, or a user.
@@ -102,7 +102,7 @@ class GuildWhitelist:
         await ctx.tick()
 
     @gwl.command(name="list")
-    async def gwl_list(self, ctx: RedContext):
+    async def gwl_list(self, ctx: commands.Context):
         """
         list whitelisted IDs
         """
@@ -116,7 +116,7 @@ class GuildWhitelist:
         await ctx.tick()
 
     @gwl.command(name="remove")
-    async def gwl_remove(self, ctx: RedContext, *ids: int):
+    async def gwl_remove(self, ctx: commands.Context, *ids: int):
         """
         remove one or more ids from the whitelist
         """
@@ -129,7 +129,7 @@ class GuildWhitelist:
         await ctx.tick()
 
     @gwl.command(name='import', disabled=True)
-    async def gwl_import(self, ctx: RedContext, path: str):
+    async def gwl_import(self, ctx: commands.Context, path: str):
         """
         pass the full path of the v2 settings.json
         for this cog

--- a/messagebox/msgbox.py
+++ b/messagebox/msgbox.py
@@ -2,13 +2,12 @@ import io
 import sys
 import discord
 from copy import copy
-from discord.ext import commands
 from redbot.core.config import Config
-from redbot.core import checks
-from redbot.core.i18n import CogI18n
+from redbot.core import checks, commands
+from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.chat_formatting import pagify
 
-_ = CogI18n('MessageBox', __file__)
+_ = Translator('MessageBox', __file__)
 
 _old_contact = None
 
@@ -17,6 +16,7 @@ class MessageBoxError(Exception):
     pass
 
 
+@cog_i18n(_)
 class MessageBox:
     """
     replace contact with something less obnoxious

--- a/relays/relays.py
+++ b/relays/relays.py
@@ -1,18 +1,17 @@
 import asyncio
 import discord
-from discord.ext import commands
 
 from redbot.core.utils.chat_formatting import box, pagify
-from redbot.core import RedContext
+from redbot.core import commands
 from redbot.core.bot import Red
 from redbot.core.config import Config
-from redbot.core.i18n import CogI18n
+from redbot.core.i18n import Translator
 from redbot.core.utils.mod import mass_purge, slow_deletion
 
 from .relay import NwayRelay, OnewayRelay
 from .helpers import unique, embed_from_msg, txt_channel_finder
 
-_ = CogI18n("Relays", __file__)
+_ = Translator("Relays", __file__)
 
 NAME_EXISTS = _("A relay of that name already exists.")
 
@@ -131,7 +130,7 @@ class Relays:
             ret[info] = val
         return ret
 
-    async def validation_error(self, ctx: RedContext, validation: dict):
+    async def validation_error(self, ctx: commands.Context, validation: dict):
         error_str = ""
         not_founds = [k for k, v in validation.items() if v is None]
         multi_match = [k for k, v in validation.items() if v is False]
@@ -146,7 +145,7 @@ class Relays:
         for page in pagify(error_str):
             await ctx.send(box(page))
 
-    async def interactive_selection(self, ctx: RedContext):
+    async def interactive_selection(self, ctx: commands.Context):
         output = ""
         names = self.relay_names
         if len(names) == 0:
@@ -211,7 +210,7 @@ class Relays:
         return msg
 
     @commands.command()
-    async def makerelay(self, ctx: RedContext, name: str, *channels: str):
+    async def makerelay(self, ctx: commands.Context, name: str, *channels: str):
         """
         Makes a multiway relay
         """
@@ -236,7 +235,7 @@ class Relays:
         await ctx.tick()
 
     @commands.command()
-    async def makeoneway(self, ctx: RedContext,
+    async def makeoneway(self, ctx: commands.Context,
                          name: str, source: str, *destinations: str):
         """
         Makes a relay which forwards a channel to one or more others
@@ -264,7 +263,7 @@ class Relays:
         await ctx.tick()
 
     @commands.command()
-    async def relayinfo(self, ctx: RedContext, name: str=None):
+    async def relayinfo(self, ctx: commands.Context, name: str=None):
         """
         gets info about relays
 
@@ -284,7 +283,7 @@ class Relays:
             await ctx.send(box(page))
 
     @commands.command()
-    async def rmrelay(self, ctx: RedContext, name: str=None):
+    async def rmrelay(self, ctx: commands.Context, name: str=None):
         """
         removes a relay
 

--- a/roomtools/autorooms.py
+++ b/roomtools/autorooms.py
@@ -3,9 +3,8 @@ import asyncio
 import contextlib
 
 import discord
-from discord.ext import commands
 
-from redbot.core import RedContext
+from redbot.core import commands
 from redbot.core.bot import Red
 from redbot.core.utils.antispam import AntiSpam
 from redbot.core.config import Config
@@ -155,7 +154,7 @@ class AutoRooms:
 
     # special checks
     def is_active_here(self):
-        async def check(ctx: RedContext):
+        async def check(ctx: commands.Context):
             return await self.config.guild(ctx.guild).active()
         return commands.check(check)
 
@@ -164,7 +163,7 @@ class AutoRooms:
     @commands.bot_has_permissions(manage_channels=True)
     @checks.admin_or_permissions(manage_channels=True)
     @commands.group()
-    async def autoroomset(self, ctx: RedContext):
+    async def autoroomset(self, ctx: commands.Context):
         """
         Commands for configuring autorooms
         """
@@ -175,7 +174,7 @@ class AutoRooms:
     @checks.admin_or_permissions(manage_channels=True)
     @autoroomset.command(name="channelsettings")
     async def setchannelsettings(
-            self, ctx: RedContext, channel: discord.VoiceChannel):
+            self, ctx: commands.Context, channel: discord.VoiceChannel):
         """
         Interactive prompt for editing the autoroom behavior for specific
         channels
@@ -236,7 +235,7 @@ class AutoRooms:
 
     @checks.admin_or_permissions(manage_channels=True)
     @autoroomset.command(name="toggleactive")
-    async def autoroomtoggle(self, ctx: RedContext, val: bool=None):
+    async def autoroomtoggle(self, ctx: commands.Context, val: bool=None):
         """
         turns autorooms on and off
         """
@@ -251,7 +250,7 @@ class AutoRooms:
     @is_active_here()
     @checks.admin_or_permissions(manage_channels=True)
     @autoroomset.command(name="makeclone")
-    async def makeclone(self, ctx: RedContext, channel: discord.VoiceChannel):
+    async def makeclone(self, ctx: commands.Context, channel: discord.VoiceChannel):
         """Takes a channel, turns that voice channel into an autoroom"""
 
         await self.config.channel(channel).autoroom.set(True)
@@ -269,7 +268,7 @@ class AutoRooms:
     @is_active_here()
     @checks.admin_or_permissions(manage_channels=True)
     @autoroomset.command(name="listautorooms")
-    async def listclones(self, ctx: RedContext):
+    async def listclones(self, ctx: commands.Context):
         """Lists the current autorooms"""
         clist = []
         for c in ctx.guild.voice_channels:
@@ -283,7 +282,7 @@ class AutoRooms:
     @is_active_here()
     @checks.admin_or_permissions(manage_channels=True)
     @autoroomset.command(name="toggleowner")
-    async def toggleowner(self, ctx: RedContext, val: bool=None):
+    async def toggleowner(self, ctx: commands.Context, val: bool=None):
         """toggles if the creator of the autoroom owns it
         requires the "Manage Channels" permission
         Defaults to false"""

--- a/roomtools/tempchannels.py
+++ b/roomtools/tempchannels.py
@@ -3,9 +3,8 @@ import asyncio
 import contextlib
 
 import discord
-from discord.ext import commands
 
-from redbot.core import RedContext
+from redbot.core import commands
 from redbot.core.bot import Red
 from redbot.core.utils.antispam import AntiSpam
 from redbot.core.config import Config
@@ -69,12 +68,12 @@ class TempChannels:
                         await conf.clear()
 
     def is_active_here(self):
-        async def check(ctx: RedContext):
+        async def check(ctx: commands.Context):
             return await self.config.guild(ctx.guild).active()
         return commands.check(check)
 
     def isnt_spam(self):
-        def check(ctx: RedContext):
+        def check(ctx: commands.Context):
             if ctx.author.id in self._antispam:
                 return not self._antispam[ctx.author.id].spammy()
             return True
@@ -84,7 +83,7 @@ class TempChannels:
     @commands.bot_has_permissions(manage_channels=True)
     @checks.admin_or_permissions(manage_channels=True)
     @commands.group(name='tempchannelset', aliases=['tmpcset'])
-    async def tmpcset(self, ctx: RedContext):
+    async def tmpcset(self, ctx: commands.Context):
         """
         Temporary Channel Settings
         """
@@ -94,7 +93,7 @@ class TempChannels:
 
     @checks.admin_or_permissions(manage_channels=True)
     @tmpcset.command()
-    async def toggleactive(self, ctx: RedContext, val: bool=None):
+    async def toggleactive(self, ctx: commands.Context, val: bool=None):
         """
         toggle (or explicitly set) whether temp channel creation is enabled
         """
@@ -112,7 +111,7 @@ class TempChannels:
     @checks.admin_or_permissions(manage_channels=True)
     @tmpcset.command(name='category')
     async def _category(
-            self, ctx: RedContext, cat: discord.CategoryChannel=None):
+            self, ctx: commands.Context, cat: discord.CategoryChannel=None):
         """
         Sets the category for temporary channels
 
@@ -130,7 +129,7 @@ class TempChannels:
     @isnt_spam()
     @commands.bot_has_permissions(manage_channels=True)
     @commands.command(name='tmpc')
-    async def create_temp(self, ctx: RedContext, *, channelname: str):
+    async def create_temp(self, ctx: commands.Context, *, channelname: str):
         """
         Creates a temporary channel
         """

--- a/roomtools/utils.py
+++ b/roomtools/utils.py
@@ -1,8 +1,8 @@
-from redbot.core import RedContext
+from redbot.core import commands
 import discord
 
 
-async def send(ctx: RedContext, content: str):
+async def send(ctx: commands.Context, content: str):
     if await ctx.embed_requested():
         return await ctx.send(embed=discord.Embed(description=content))
     else:


### PR DESCRIPTION
Specifically those created in Cog-Creators/Red-DiscordBot#1143.

`discord.ext.commands` -> `redbot.core.commands`
`RedContext` -> `commands.Context`
`CogI18n` -> `Translator`

Also any cogs which previously had i18n set up now have their cogs decorated with `@cog_i18n`!