### PR TITLE
fix toggleowner

### DIFF
--- a/roomtools/autorooms.py
+++ b/roomtools/autorooms.py
@@ -273,8 +273,8 @@ class AutoRooms(MixedMeta):
         requires the "Manage Channels" permission
         Defaults to false"""
         if val is None:
-            val = not await self.ar_config.guild(ctx.guild).active()
-        await self.ar_config.guild(ctx.guild).active.set(val)
+            val = not await self.ar_config.guild(ctx.guild).ownership()
+        await self.ar_config.guild(ctx.guild).ownership.set(val)
         await ctx.send(
             (
                 "Autorooms are "


### PR DESCRIPTION
`[p]autoroomset toggleowner` was incorrectly toggling whether autorooms were active