### PR TITLE
[RoomTools] Add a setting to show autoroom creator name after channel name

### DIFF
--- a/roomtools/__init__.py
+++ b/roomtools/__init__.py
@@ -57,7 +57,7 @@ class RoomTools(AutoRooms, TempChannels, commands.Cog, metaclass=CompositeMetaCl
         )
         self.ar_config.register_guild(active=False, ownership=False)
         self.ar_config.register_channel(
-            ownership=None, gameroom=False, autoroom=False, clone=False
+            ownership=None, gameroom=False, autoroom=False, clone=False, creatorname=False
         )
         self.bot.loop.create_task(self.tmpc_cleanup(load=True))
         self.bot.loop.create_task(self.ar_cleanup(load=True))

--- a/roomtools/autorooms.py
+++ b/roomtools/autorooms.py
@@ -124,7 +124,8 @@ class AutoRooms(MixedMeta):
             with contextlib.suppress(Exception):
                 cname = who.activity.name
         else:
-            cname = source.name
+            creatorname = await self.ar_config.channel(source).creatorname()
+            cname = source.name if not creatorname else source.name + f" {who.name}"
 
         try:
             chan = await source.guild.create_voice_channel(
@@ -226,7 +227,7 @@ class AutoRooms(MixedMeta):
         if val is None:
             val = not await self.ar_config.guild(ctx.guild).active()
         await self.ar_config.guild(ctx.guild).active.set(val)
-        await ctx.send(("Autorooms are now " + "activated" if val else "deactivated"))
+        await ctx.send(("Autorooms are now " + ("activated" if val else "deactivated")))
 
     @aa_active()
     @checks.admin_or_permissions(manage_channels=True)
@@ -274,5 +275,24 @@ class AutoRooms(MixedMeta):
                 "Autorooms are "
                 + ("now owned " if val else "no longer owned ")
                 + "by their creator"
+            )
+        )
+
+    @aa_active()
+    @checks.admin_or_permissions(manage_channels=True)
+    @autoroomset.command(name="creatorname")
+    async def creatorname(
+        self, ctx: commands.Context, channel: discord.VoiceChannel, val: bool = None
+    ):
+        """Toggles if an autoroom will get the owner name after the channel name."""
+        if val is None:
+            val = not await self.ar_config.channel(channel).creatorname()
+        await self.ar_config.channel(channel).creatorname.set(val)
+        await ctx.send(
+            f"Channel `{channel.name}` "
+            + (
+                "will now have creator name after their name."
+                if val
+                else "will no longer have creator name after their name."
             )
         )


### PR DESCRIPTION
This PR adds a new setting, that can show the autoroom creator after the channel name and also fix the output of `[p]autoroomset toggleactive` on disabling.