### PR TITLE
[RoomTools] Fix "Custom Status" always showing as the game room

### DIFF
--- a/roomtools/autorooms.py
+++ b/roomtools/autorooms.py
@@ -122,7 +122,7 @@ class AutoRooms(MixedMeta):
         if await self.ar_config.channel(source).gameroom():
             cname = "???"
             with contextlib.suppress(Exception):
-                cname = who.activity.name
+                cname = discord.utils.get(who.activities, type=discord.ActivityType.try_value(0)).name
         else:
             creatorname = await self.ar_config.channel(source).creatorname()
             cname = source.name if not creatorname else source.name + f" {who.name}"


### PR DESCRIPTION
Since I know we all love breaking Discord changes