### PR TITLE
[BanSync] Fix issue with modlog case in BanSync

### DIFF
--- a/bansync/bansync.py
+++ b/bansync/bansync.py
@@ -361,7 +361,7 @@ class BanSync(commands.Cog):
             return False
         else:
             await create_case(
-                self.bot, guild, datetime.utcnow(), "ban", member, mod, reason
+                self.bot, guild, datetime.utcnow(), "ban", _id, mod, reason
             )
 
         return True


### PR DESCRIPTION
When globalban is used the modlog case call fails because it's expecting an actual member object or an int. This replaces the mock member object with the ID that modlog can now use instead.